### PR TITLE
Changing the "steering committee members" label for "strategic members".

### DIFF
--- a/layouts/membership/members.html
+++ b/layouts/membership/members.html
@@ -4,7 +4,7 @@
     <div class="container" id="members">
       <p>Learn more about our members and discover the IoT solutions they offer today.
       </p>
-      <h2 class="purple">Steering committee members<br /><br /></h2>
+      <h2 class="purple">Strategic members<br /><br /></h2>
       <div id="sc-members">
         {{ range where .Site.RegularPages.ByTitle "Section" "member" }}
         {{ if eq .Params.member_type "steering" }}


### PR DESCRIPTION
This puts the page in line with the titles defined in our WG charter.

Signed-off-by: Frédéric Desbiens <frederic.desbiens@eclipse-foundation.org>