### PR TITLE
MQTT sandbox tweaks

### DIFF
--- a/layouts/getting-started/section.html
+++ b/layouts/getting-started/section.html
@@ -61,14 +61,14 @@
           </p>
           <p>
             Access the server using the hostname
-            <code>iot.eclipse.org</code> and port
+            <code>mqtt.eclipse.org</code> and port
             <code>1883</code>. You can also access the server using encrypted port <code>8883</code>
             <br/>
             The encrypted port support TLS v1.2, v1.1 or v1.0 with x509 certificates and requires client support to connect.
           </p>
-          <p>
+          <!--  
             You can also use <strong>MQTT over WebSockets</strong>, both plain and secured, using the following connection URIs (respectively): <code>ws://iot.eclipse.org:80/ws</code> and <code>wss://iot.eclipse.org:443/ws</code>  
-          </p>
+          </p -->
           <p>
             This server is running the open source <a href="http://mosquitto.org/">Mosquitto broker</a> in its most recently released version.
           </p>


### PR DESCRIPTION
Changed the hostname to mqtt.eclipse.org.
Removed the Websockets reference as we try to make it work.

Signed-off-by: Frédéric Desbiens <frederic.desbiens@eclipse-foundation.org>