### PR TITLE
Remove Orange from the IoT website #188

### DIFF
--- a/content/member/orange.md
+++ b/content/member/orange.md
@@ -1,8 +1,0 @@
-+++
-date = "2017-10-20T15:31:21-07:00"
-title = "Orange"
-logo = "orange" #make sure to have a file named [logo].png in the static/assets/images/members/ folder
-member_type = "participating"
-member_id = 1265
-more_url = "http://www.orange.com"
-+++


### PR DESCRIPTION
Removed Orange member page

Change-Id: I2576b011e4e679ba65783984f7ece319cef73e93
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>