### PR TITLE
Use --unsafe-perm npm flags inside docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN echo -n "Node.js version " && node --version \
   && echo -n "npm version " && npm --version \
   && hugo version
 
-RUN npm ci \
-    && npm run production \
+RUN npm --unsafe-perm ci \
+    && npm run --unsafe-perm production \
     && hugo
 
 FROM eclipsefdn/nginx:${NGINX_IMAGE_TAG}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN echo -n "Node.js version " && node --version \
   && hugo version
 
 RUN npm --unsafe-perm ci \
-    && npm run --unsafe-perm production \
     && hugo
 
 FROM eclipsefdn/nginx:${NGINX_IMAGE_TAG}


### PR DESCRIPTION
From https://docs.npmjs.com/misc/scripts#user

If npm was invoked with root privileges, then it will change the uid to the user account or uid specified by the user config, which defaults to nobody. Set the unsafe-perm flag to run scripts with root privileges.