### PR TITLE
Add othermo to vorto adopters

### DIFF
--- a/data/adopters.yml
+++ b/data/adopters.yml
@@ -27,6 +27,11 @@ adopters:
       logo: logo-aloxy.svg
       logo_white: logo-aloxy-white.svg
 
+    - name: othermo
+      homepage_url: https://othermo.de
+      logo: logo-othermo.svg
+      logo_white: logo-othermo-white.svg
+
   - name: Eclipse Hono
     id: iot.hono
     adopters:


### PR DESCRIPTION
Since we are also using Eclipse Vorto in tandem with Eclipse Ditto,
leveraging their synergies, this adds the othermo GmbH logo to the
vorto adopters section on the page.

Signed-off-by: Alexander Wellbrock <a.wellbrock@mailbox.org>