### PR TITLE
Adopter contains wrong URL #229

### DIFF
--- a/data/adopters.yml
+++ b/data/adopters.yml
@@ -33,7 +33,7 @@ adopters:
       logo_white: logo-othermo-white.svg
       
     - name: Bosch Software Innovations
-      homepage_url: https://www.bosch-iot-suite.com/service/things/
+      homepage_url: https://www.bosch-iot-suite.com
       logo: logo-bosch.svg
       logo_white: logo-bosch-white.svg
 
@@ -51,7 +51,7 @@ adopters:
       logo_white: logo-aloxy-white.svg
       
     - name: Bosch Software Innovations
-      homepage_url: https://www.bosch-iot-suite.com/service/things/
+      homepage_url: https://www.bosch-iot-suite.com/service/hub/
       logo: logo-bosch.svg
       logo_white: logo-bosch-white.svg
       
@@ -77,6 +77,6 @@ adopters:
     adopters:
       
     - name: Bosch Software Innovations
-      homepage_url: https://www.bosch-iot-suite.com/service/things/
+      homepage_url: https://www.bosch-iot-suite.com/service/rollouts/
       logo: logo-bosch.svg
       logo_white: logo-bosch-white.svg


### PR DESCRIPTION
Updated Hono, Vorto, and hawkBit entries for Bosch.

Change-Id: Ia16636f9a4b83501c1f0bdc677bd5d0749c7d163
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>