### PR TITLE
Adding Sparkplug launch in the Eclipse IoT news.

### DIFF
--- a/content/news/2020-02-03-sparkplug-launch.md
+++ b/content/news/2020-02-03-sparkplug-launch.md
@@ -1,0 +1,6 @@
++++
+date = "2020-02-03"
+title = "The Eclipse Foundation launches the Sparkplug Working Group"
+link = "https://www.globenewswire.com/news-release/2020/02/03/1978911/0/en/The-Eclipse-Foundation-Launches-the-Sparkplug-Working-Group-to-Bring-Device-Communications-Standardization-to-the-Industrial-Internet-of-Things-and-Industrial-Automation.html"
++++
+On February 3, 2020 the Eclipse Foundation announced the launch of the Sparkplug Working Group, which is driving the evolution and broad adoption of the Eclipse Sparkplug Specification that enables the creation of open, interoperable, Industrial IoT (IIoT) solutions utilizing MQTT. Founding members include global leaders Chevron, Canary Labs, Cirrus Link Solutions, HiveMQ, Inductive Automation, and ORing.


### PR DESCRIPTION
Signed-off-by: Frédéric Desbiens <frederic.desbiens@eclipse-foundation.org>