### PR TITLE
Added test to build steps to error out on bad data for adopters

### DIFF
--- a/bin/adopters.sh
+++ b/bin/adopters.sh
@@ -11,9 +11,15 @@
 # 
 # SPDX-License-Identifier: EPL-2.0
 # ===========================================================================
-
+echo 'Building adopters data set';
 rm -f static/assets/js/eclipsefdn.adopters.js && touch static/assets/js/eclipsefdn.adopters.js
 rm -f static/assets/js/eclipsefdn.adopters.json && touch static/assets/js/eclipsefdn.adopters.json
 ./node_modules/js-yaml/bin/js-yaml.js -c data/adopters.yml | ./node_modules/json-minify/index.js > static/assets/js/eclipsefdn.adopters.json 
+echo 'Validating JSON data is present';
+if [[ ! -s ./static/assets/js/eclipsefdn.adopters.json ]]; then
+  echo "ERROR: Adopters JSON should not be empty, ending now"
+  exit 1;
+fi
+echo 'Creating js file';
 (echo -n "var json_adopters = '"; cat ./static/assets/js/eclipsefdn.adopters.json | tr -d '\n'; echo "';"; cat ./node_modules/eclipsefdn-solstice-assets/js/eclipsefdn.adopters.js ) \
   > static/assets/js/eclipsefdn.adopters.js


### PR DESCRIPTION
This affects terminal, Jenkins, Travis, and Docker builds (as all make
use of this script through NPM). This should stop bad data from being
pushed to production, allowing for reruns.


Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>