### PR TITLE
Removed travisci build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ The [iot.eclipse.org](https://iot.eclipse.org) website is generated with [Hugo](
 
 Eclipse IoT provides the technology needed to build IoT Devices, Gateways, and Cloud Platforms.
 
-[![Build Status](https://travis-ci.org/EclipseFdn/iot.eclipse.org.svg?branch=master)](https://travis-ci.org/EclipseFdn/iot.eclipse.org)
-
 ## Getting started
 
 Install dependencies, build website and start a simple webserver:


### PR DESCRIPTION
If needed, we can add a "badge plugin" to the Jenkins instance running the build to replace this one.