### PR TITLE
Update Californium's sandbox url to eclipseprojects.io.

### DIFF
--- a/layouts/shortcodes/projects/page-sandboxes.html
+++ b/layouts/shortcodes/projects/page-sandboxes.html
@@ -34,7 +34,7 @@
     </p>
 
     <h2 id="sandbox-coap">CoAP</h2>
-    <p>A CoAP server exposing test resources is available at: <code>coap://californium.eclipse.org:5683/</code>, and DTLS-enabled version at <code>coaps://californium.eclipse.org:5684</code>.</p>
+    <p>A CoAP server exposing test resources is available at: <code>coap://californium.eclipseprojects.io:5683/</code>, and DTLS-enabled version at <code>coaps://californium.eclipseprojects.io:5684</code>.</p>
     <p>It should be used by anyone interested in testing a CoAP client implementation against another endpoint, and more generally by anyone interested in understanding the key concepts of the CoAP protocol.</p>
     <p>
       This server is running <a href="https://projects.eclipse.org/projects/technology.californium">Eclipse Californium</a>.


### PR DESCRIPTION
Signed-off-by: Achim Kraus <achim.kraus@bosch.io>